### PR TITLE
Bug Fix:  Malicious clients can cause an unhandled exception

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -582,7 +582,8 @@ SMTPConnection.prototype.handler_AUTH = function(command, callback) {
 
     args.shift(); // remove AUTH
     method = (args.shift() || '').toString().toUpperCase(); // get METHOD and keep additional arguments in the array
-    handler = sasl['SASL_' + method].bind(this);
+    handler = sasl['SASL_' + method];
+    handler = handler ? handler.bind(this) : handler;
 
     if (!this.secure && this._isSupported('STARTTLS') && !this._server.options.hideSTARTTLS) {
         this.send(538, 'Error: Must issue a STARTTLS command first');


### PR DESCRIPTION
Issue:  In smtp-connection's auth handler, it directly uses network input as a key with an object.  If that key does not exist, then undefined will be returned, and immediately bind will be called, resulting in an exception.  Can reproduce by:
EHLO localhost
AUTH evil

Causes sasl["sasl_evil"].bind(this) to be executed.

Fix:  Check to see if the key exists; only call bind(this) if a truthy object is returned.