### PR TITLE
EHLO/HELO have an empty tirth argument

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -429,7 +429,7 @@ SMTPConnection.prototype._startSession = function() {
  * Processes EHLO. Requires valid hostname as the single argument.
  */
 SMTPConnection.prototype.handler_EHLO = function(command, callback) {
-    var parts = command.toString().split(/\s+/);
+    var parts = command.toString().trim().split(/\s+/);
     var hostname = parts[1] || '';
 
     if (parts.length !== 2) {
@@ -463,7 +463,7 @@ SMTPConnection.prototype.handler_EHLO = function(command, callback) {
  * Processes HELO. Requires valid hostname as the single argument.
  */
 SMTPConnection.prototype.handler_HELO = function(command, callback) {
-    var parts = command.toString().split(/\s+/);
+    var parts = command.toString().trim().split(/\s+/);
     var hostname = parts[1] || '';
 
     if (parts.length !== 2) {


### PR DESCRIPTION
When connected with OpenSSL, the server rejects the EHLO/HELO commands because there is an empty tirth argument. This trims the empty space and resolves the issue