### PR TITLE
Patched Code to Prevent a Throw

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -815,7 +815,7 @@ SMTPConnection.prototype.handler_DATA = function(command, callback) {
     this._server.onData(this._dataStream, this.session, function(err, message) {
         // ensure _dataStream is an object and not set to null by premature closing
         // do not continue until the stream has actually ended
-        if ((typeof this._dataStream === 'object') && (this._dataStream.readable)) {
+        if ((typeof this._dataStream === 'object') && (this._dataStream) && (this._dataStream.readable)) {
             this._dataStream.on('end', function() {
                 close(err, message);
             });

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -813,8 +813,9 @@ SMTPConnection.prototype.handler_DATA = function(command, callback) {
     }.bind(this);
 
     this._server.onData(this._dataStream, this.session, function(err, message) {
+        // ensure _dataStream is an object and not set to null by premature closing
         // do not continue until the stream has actually ended
-        if (this._dataStream.readable) {
+        if ((typeof this._dataStream === 'object') && (this._dataStream.readable)) {
             this._dataStream.on('end', function() {
                 close(err, message);
             });


### PR DESCRIPTION
If _dataStream is not an object, a TypeError will be thrown. This
ensures that _dataStream is an object and not set to null by premature
closing.

Reference: Issue #27 