### PR TITLE
Only 421 error closes socket; changed error codes for syntax errors…

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -296,7 +296,7 @@ SMTPConnection.prototype._onCommand = function (command, callback) {
 
     // block malicious web pages that try to make SMTP calls from an AJAX request
     if (/^(OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT) \/.* HTTP\/\d\.\d$/i.test(command)) {
-        this.send(500, 'HTTP requests not allowed');
+        this.send(421, 'HTTP requests not allowed');
     }
 
     callback = callback || function () {};

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -108,7 +108,6 @@ SMTPConnection.prototype.init = function () {
     // Check that connection limit is not exceeded
     if (this._server.options.maxClients && this._server.connections.size > this._server.options.maxClients) {
         this.send(421, this.name + ' Too many connected clients, try again in a moment');
-        return this.close();
     }
 
     if (!this._server.options.useProxy) {
@@ -135,7 +134,6 @@ SMTPConnection.prototype.connectionReady = function (next) {
         this._server.onConnect(this.session, function (err) {
             if (err) {
                 this.send(err.responseCode || 554, err.message);
-                this.close();
             }
 
             this._ready = true; // Start accepting data from input
@@ -176,6 +174,10 @@ SMTPConnection.prototype.send = function (code, data) {
     if (this._socket && this._socket.writable) {
         this._socket.write(payload + '\r\n');
         this._server.logger.debug('[%s] S:', this._id, payload);
+    }
+
+    if (code === 421) {
+        this.close();
     }
 };
 
@@ -255,8 +257,7 @@ SMTPConnection.prototype._onError = function (err) {
  * @event
  */
 SMTPConnection.prototype._onTimeout = function () {
-    this.send(451, 'Timeout - closing connection');
-    this.close();
+    this.send(421, 'Timeout - closing connection');
 };
 
 /**
@@ -290,14 +291,12 @@ SMTPConnection.prototype._onCommand = function (command, callback) {
         } else {
             // block spammers that send payloads before server greeting
             this.send(421, this.name + ' You talk too soon');
-            return this.close();
         }
     }
 
     // block malicious web pages that try to make SMTP calls from an AJAX request
     if (/^(OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT) \/.* HTTP\/\d\.\d$/i.test(command)) {
-        this.send(554, 'HTTP requests not allowed');
-        return this.close();
+        this.send(500, 'HTTP requests not allowed');
     }
 
     callback = callback || function () {};
@@ -323,8 +322,7 @@ SMTPConnection.prototype._onCommand = function (command, callback) {
         // if the user makes more
         this._unrecognizedCommands++;
         if (this._unrecognizedCommands >= 10) {
-            this.send(554, 'Error: too many unrecognized commands');
-            return this.close();
+            this.send(421, 'Error: too many unrecognized commands');
         }
 
         this.send(500, 'Error: command not recognized');
@@ -335,8 +333,7 @@ SMTPConnection.prototype._onCommand = function (command, callback) {
     if (!this.session.user && this._isSupported('AUTH') && commandName !== 'AUTH') {
         this._unauthenticatedCommands++;
         if (this._unauthenticatedCommands >= 10) {
-            this.send(554, 'Error: too many unauthenticated commands');
-            return this.close();
+            this.send(421, 'Error: too many unauthenticated commands');
         }
     }
 
@@ -776,7 +773,7 @@ SMTPConnection.prototype.handler_XFORWARD = function (command, callback) {
 SMTPConnection.prototype.handler_STARTTLS = function (command, callback) {
 
     if (this.secure) {
-        this.send(554, 'Error: TLS already active');
+        this.send(503, 'Error: TLS already active');
         return callback();
     }
 
@@ -954,7 +951,7 @@ SMTPConnection.prototype.handler_DATA = function (command, callback) {
         this._dataStream.removeAllListeners();
 
         if (err) {
-            this.send(err.responseCode || 554, err.message);
+            this.send(err.responseCode || 450, err.message);
         } else {
             this.send(250, typeof message === 'string' ? message : 'OK: message queued');
         }

--- a/test/smtp-connection-test.js
+++ b/test/smtp-connection-test.js
@@ -526,7 +526,7 @@ describe('SMTPServer', function () {
                 });
                 socket.on('end', function () {
                     var data = Buffer.concat(buffers).toString();
-                    expect(/^554 /m.test(data)).to.be.true;
+                    expect(/^500 /m.test(data)).to.be.true;
                     done();
                 });
             });
@@ -1123,7 +1123,9 @@ describe('SMTPServer', function () {
             useProxy: true,
             onConnect: function (session, callback) {
                 if (session.remoteAddress === '1.2.3.4') {
-                    return callback(new Error('Blacklisted IP'));
+                    var err = new Error('Blacklisted IP');
+                    err.responseCode = 421;
+                    return callback(err);
                 }
                 callback();
             }
@@ -1170,7 +1172,7 @@ describe('SMTPServer', function () {
                 });
                 socket.on('end', function () {
                     var data = Buffer.concat(buffers).toString();
-                    expect(data.indexOf('554 ')).to.equal(0);
+                    expect(data.indexOf('421 ')).to.equal(0);
                     expect(data.indexOf('Blacklisted')).to.gte(4);
                     done();
                 });

--- a/test/smtp-connection-test.js
+++ b/test/smtp-connection-test.js
@@ -526,7 +526,7 @@ describe('SMTPServer', function () {
                 });
                 socket.on('end', function () {
                     var data = Buffer.concat(buffers).toString();
-                    expect(/^500 /m.test(data)).to.be.true;
+                    expect(/^421 /m.test(data)).to.be.true;
                     done();
                 });
             });


### PR DESCRIPTION
…and after DATA so they are more RFC 2821 compatible.

Hi.

I miss the possibility for closing the SMTP session from custom hook.

As far as I understand RFC2821 correctly, SMTP server should close SMTP session after 421 error and that's why is the new feature: connection.send method checks if the code is 421 and then closes the connection.

I do not close automatically the connection after syntax error. It was against RFC2821 paragraph 3.6

> In particular, a server that closes connections in response to
   commands that are not understood is in violation of this
   specification.  Servers are expected to be tolerant of unknown
   commands, issuing a 500 reply and awaiting further instructions from
   the client.

So, this patch should make the smtp-server to be more RFC compatible.
