### PR TITLE
More checks if stream is ended

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -951,7 +951,9 @@ SMTPConnection.prototype.handler_DATA = function (command, callback) {
     var close = function (err, message) {
         this._server.logger.debug('[%s] C: <%s bytes of DATA>', this._id, this._parser.dataBytes);
 
-        this._dataStream.removeAllListeners();
+        if ((typeof this._dataStream === 'object') && (this._dataStream) && (this._dataStream.readable)) {
+            this._dataStream.removeAllListeners();
+        }
 
         if (err) {
             this.send(err.responseCode || 554, err.message);
@@ -963,7 +965,10 @@ SMTPConnection.prototype.handler_DATA = function (command, callback) {
 
         this._unrecognizedCommands = 0; // reset unrecognized commands counter
         this._resetSession(); // reset session state
-        this._parser.continue();
+
+        if ((typeof this._parser === 'object') && (this._parser)) {
+            this._parser.continue();
+        }
     }.bind(this);
 
     this._server.onData(this._dataStream, this.session, function (err, message) {


### PR DESCRIPTION
For bad SMTP streams I get sometimes:

```
TypeError: Cannot read property 'removeAllListeners' of null
    at SMTPConnection.<anonymous> (/home/dexter/node_modules/smtp-server/lib/smtp-connection.js:951:25)
    at SMTPConnection.<anonymous> (/home/dexter/node_modules/smtp-server/lib/smtp-connection.js:975:9)
    at Immediate.immediate._onImmediate (timers.js:585:18)
    at tryOnImmediate (timers.js:543:15)
    at processImmediate [as _immediateCallback] (timers.js:523:5)
```

Bad stream is ie. stream which contains additional single dot "." before final dot in DATA body. I've found this error in some buggy SMTP session with over 100 mails in one session. I'm not sure if I could reproduce it as test spec.

I've found that simple doublechecking if stream object is still exist is just enough to prevent this error which just crushes whole SMTP server.
