### PR TITLE
smtp-connection this.server.options bug fix

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -354,7 +354,7 @@ SMTPConnection.prototype._onCommand = function (command, callback) {
     }
 
     // Check if authentication is required
-    if (!this.session.user && this._isSupported('AUTH') && ['MAIL', 'RCPT', 'DATA'].indexOf(commandName) >= 0 && !this.server.options.authOptional) {
+    if (!this.session.user && this._isSupported('AUTH') && ['MAIL', 'RCPT', 'DATA'].indexOf(commandName) >= 0 && !this._server.options.authOptional) {
         this.send(530, 'Error: authentication Required');
         return setImmediate(callback);
     }


### PR DESCRIPTION
Fixing (typo) `this.server.options` to `this._server.options` (#https://github.com/andris9/smtp-server/issues/57).