### PR TITLE
Opening command

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ Session object that is passed to the handler functions includes the following pr
   * **id** random string identificator generated when the client connected
   * **remoteAddress** the IP address for the connected client
   * **clientHostname** reverse resolved hostname for *remoteAddress*
+  * **openingCommand** the opening SMTP command (HELO/EHLO/LHLO)
   * **hostNameAppearsAs** hostname the client provided with HELO/EHLO call
   * **envelope** includes denvelope data
     * **mailFrom** includes an address object or is set to false

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -316,15 +316,20 @@ SMTPConnection.prototype._onCommand = function (command, callback) {
     } else {
         // detect handler from the command name
         commandName = (command || '').toString().split(' ').shift().toUpperCase();
+        switch (commandName) {
+            case 'HELO':
+            case 'EHLO':
+            case 'LHLO':
+                this.openingCommand = commandName;
+                break;
+        }
         if (this._server.options.lmtp) {
             switch (commandName) {
                 case 'HELO':
                 case 'EHLO':
-                    this.openingCommand = commandName;
                     this.send(500, 'Error: ' + commandName + ' not allowed in LMTP server');
                     return setImmediate(callback);
                 case 'LHLO':
-                    this.openingCommand = commandName;
                     commandName = 'EHLO';
                     break;
             }

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -82,6 +82,9 @@ function SMTPConnection(server, socket) {
     // Resolved hostname for remote IP address
     this.clientHostname = false;
 
+    // The opening SMTP command (HELO, EHLO or LHLO)
+    this.openingCommand = false;
+
     // The hostname client identifies itself with
     this.hostNameAppearsAs = false;
 
@@ -317,9 +320,11 @@ SMTPConnection.prototype._onCommand = function (command, callback) {
             switch (commandName) {
                 case 'HELO':
                 case 'EHLO':
+                    this.openingCommand = commandName;
                     this.send(500, 'Error: ' + commandName + ' not allowed in LMTP server');
                     return setImmediate(callback);
                 case 'LHLO':
+                    this.openingCommand = commandName;
                     commandName = 'EHLO';
                     break;
             }
@@ -449,6 +454,7 @@ SMTPConnection.prototype._resetSession = function () {
     // reset data that might be overwritten
     session.remoteAddress = this.remoteAddress;
     session.clientHostname = this.clientHostname;
+    session.openingCommand = this.openingCommand
     session.hostNameAppearsAs = this.hostNameAppearsAs;
     session.xClient = this._xClient;
     session.xForward = this._xForward;


### PR DESCRIPTION
This is the implementation for new session's attribute which contains opening SMTP command (HELO, EHLO or LHLO).

This information might be useful if you want to distinct SMTP, ESMTP or LMTP protocol with in same  onXxx callback.
