### PR TITLE
Resolve ipv4 address on ipv6 interface

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -65,7 +65,7 @@ function SMTPConnection(server, socket) {
     this.tlsOptions = this.secure ? this._socket.getCipher() : false;
 
     // Store remote address for later usage
-    this.remoteAddress = this._socket.remoteAddress;
+    this.remoteAddress = this._socket.remoteAddress.replace(/^::ffff:/, '');
 
     // normalize IPv6 addresses
     if (this.remoteAddress && net.isIPv6(this.remoteAddress)) {
@@ -158,7 +158,7 @@ SMTPConnection.prototype.connectionReady = function (next) {
 
     try {
         // dns.reverse throws on invalid input, see https://github.com/nodejs/node/issues/3112
-        dns.reverse((this.remoteAddress.replace(/^::ffff:/, '') || '').toString(), reverseCb);
+        dns.reverse((this.remoteAddress || '').toString(), reverseCb);
     } catch (E) {
         reverseCb(E);
     }

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -65,7 +65,7 @@ function SMTPConnection(server, socket) {
     this.tlsOptions = this.secure ? this._socket.getCipher() : false;
 
     // Store remote address for later usage
-    this.remoteAddress = this._socket.remoteAddress.replace(/^::ffff:/, '');
+    this.remoteAddress = (this._socket.remoteAddress || '').replace(/^::ffff:/, '');
 
     // normalize IPv6 addresses
     if (this.remoteAddress && net.isIPv6(this.remoteAddress)) {
@@ -158,7 +158,7 @@ SMTPConnection.prototype.connectionReady = function (next) {
 
     try {
         // dns.reverse throws on invalid input, see https://github.com/nodejs/node/issues/3112
-        dns.reverse((this.remoteAddress || '').toString(), reverseCb);
+        dns.reverse(this.remoteAddress.toString(), reverseCb);
     } catch (E) {
         reverseCb(E);
     }
@@ -707,7 +707,7 @@ SMTPConnection.prototype.handler_XCLIENT = function (command, callback) {
 
                     // store original value for reference as ADDR:DEFAULT
                     if (!this._xClient.has('ADDR:DEFAULT')) {
-                        this._xClient.set('ADDR:DEFAULT', this.remoteAddress || '');
+                        this._xClient.set('ADDR:DEFAULT', this.remoteAddress);
                     }
 
                     this.remoteAddress = value;

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -158,7 +158,7 @@ SMTPConnection.prototype.connectionReady = function (next) {
 
     try {
         // dns.reverse throws on invalid input, see https://github.com/nodejs/node/issues/3112
-        dns.reverse((this.remoteAddress || '').toString(), reverseCb);
+        dns.reverse((this.remoteAddress.replace(/^::ffff:/, '') || '').toString(), reverseCb);
     } catch (E) {
         reverseCb(E);
     }


### PR DESCRIPTION
If smtp-server is listening on default interface (ipv6 by default) and incoming connection is from ipv4 address, then remoteAddress contains ::ffff: prefix, ie. remoteAddress="::ffff:192.168.1.2"

Unfortunately, then dns.reverse method fails so ipv4 addresses can't be resolved.

It was tested on Debian 8 and OS X 10.11

This patch just normalizes the remoteAddress so the ipv4 address can be properly resolved.
